### PR TITLE
Add initial prototype Event Management files

### DIFF
--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -49,5 +49,6 @@ BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks);
 char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type);
 BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
                                 char const * EventText, ...);
+void BPL_EVM_Deinitialize(void);
 
 #endif /* BPL_EVM_H */

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -27,12 +27,6 @@ typedef enum
 
 typedef struct
 {
-    BPL_EVM_EventType_t Type;
-    uint16_t ID;
-} BPL_EVM_EventInfo_t;
-
-typedef struct
-{
     uint32_t ReturnValue;
 } BPL_Status_t;
 
@@ -53,6 +47,7 @@ typedef struct
 
 BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks);
 char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type);
-BPL_Status_t BPL_EVM_SendEvent(BPL_EVM_EventInfo_t const * EventInfo, char const * EventText, ...);
+BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
+                                char const * EventText, ...);
 
 #endif /* BPL_EVM_H */

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -17,6 +17,7 @@
 
 typedef enum
 {
+    BPL_EVM_EventType_UNKNOWN = 0,
     BPL_EVM_EventType_DEBUG = 1,
     BPL_EVM_EventType_INFO = 2,
     BPL_EVM_EventType_WARNING = 3,
@@ -39,21 +40,8 @@ typedef struct
  * Exported Functions
  ************************************************/
 
-/* TODO: try this later
-static inline char *BPL_EVM_EventTypeToString(enum BPL_EVM_EventType_t Type)
-{
-    static const char *BPL_EVM_EventTypeStrings[] = {
-        "DEBUG",
-        "INFO",
-        "WARNING",
-        "ERROR",
-        "CRITICAL"
-    };
-    return BPL_EVM_EventTypeStrings[Type];
-}
-*/
-
 BPL_Status_t BPL_EVM_Initialize(void);
+char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type);
 BPL_Status_t BPL_EVM_SendEvent(BPL_EVM_EventInfo_t const * EventInfo, char const * EventText, ...);
 
 #endif /* BPL_EVM_H */

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -38,7 +38,7 @@ typedef struct
 typedef struct
 {
     BPL_Status_t (*Initialize_Impl)(void);
-    BPL_Status_t (*SendEvent_Impl)(uint32_t EventID);
+    BPL_Status_t (*SendEvent_Impl)(uint16_t EventID);
 } BPL_EVM_ProxyCallbacks_t;
 
 /************************************************

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -38,7 +38,7 @@ typedef struct
 typedef struct
 {
     BPL_Status_t (*Initialize_Impl)(void);
-    BPL_Status_t (*SendEvent_Impl)(uint16_t EventID);
+    BPL_Status_t (*SendEvent_Impl)(uint16_t EventID, BPL_EVM_EventType_t EventType);
 } BPL_EVM_ProxyCallbacks_t;
 
 /************************************************

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -36,11 +36,22 @@ typedef struct
     uint32_t ReturnValue;
 } BPL_Status_t;
 
+#define BPL_STATUS_SUCCESS             (0u)
+#define BPL_STATUS_ERROR_GENERAL       (1u)
+#define BPL_STATUS_ERROR_INPUT_INVALID (2u)
+#define BPL_STATUS_ERROR_PROXY_INIT    (3u)
+
+typedef struct
+{
+    BPL_Status_t (*Initialize_Impl)(void);
+    BPL_Status_t (*SendEvent_Impl)(uint32_t EventID);
+} BPL_EVM_ProxyCallbacks_t;
+
 /************************************************
  * Exported Functions
  ************************************************/
 
-BPL_Status_t BPL_EVM_Initialize(void);
+BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks);
 char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type);
 BPL_Status_t BPL_EVM_SendEvent(BPL_EVM_EventInfo_t const * EventInfo, char const * EventText, ...);
 

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -1,0 +1,59 @@
+/*
+ * TODO: Fill in file header, if necessary.
+ */
+
+#ifndef BPL_EVM_H
+#define BPL_EVM_H
+
+/******************************************************************************
+ INCLUDES
+ ******************************************************************************/
+
+#include "bplib_api_types.h"
+
+/************************************************
+ * Typedefs
+ ************************************************/
+
+typedef enum
+{
+    BPL_EVM_EventType_DEBUG = 1,
+    BPL_EVM_EventType_INFO = 2,
+    BPL_EVM_EventType_WARNING = 3,
+    BPL_EVM_EventType_ERROR = 4,
+    BPL_EVM_EventType_CRITICAL = 5
+} BPL_EVM_EventType_t;
+
+typedef struct
+{
+    BPL_EVM_EventType_t Type;
+    uint16_t ID;
+} BPL_EVM_EventInfo_t;
+
+typedef struct
+{
+    uint32_t ReturnValue;
+} BPL_Status_t;
+
+/************************************************
+ * Exported Functions
+ ************************************************/
+
+/* TODO: try this later
+static inline char *BPL_EVM_EventTypeToString(enum BPL_EVM_EventType_t Type)
+{
+    static const char *BPL_EVM_EventTypeStrings[] = {
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL"
+    };
+    return BPL_EVM_EventTypeStrings[Type];
+}
+*/
+
+BPL_Status_t BPL_EVM_Initialize(void);
+BPL_Status_t BPL_EVM_SendEvent(BPL_EVM_EventInfo_t const * EventInfo, char const * EventText, ...);
+
+#endif /* BPL_EVM_H */

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -38,7 +38,8 @@ typedef struct
 typedef struct
 {
     BPL_Status_t (*Initialize_Impl)(void);
-    BPL_Status_t (*SendEvent_Impl)(uint16_t EventID, BPL_EVM_EventType_t EventType);
+    BPL_Status_t (*SendEvent_Impl)(uint16_t EventID, BPL_EVM_EventType_t EventType,
+        char const * EventText, va_list EventTextArgPtr);
 } BPL_EVM_ProxyCallbacks_t;
 
 /************************************************

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -37,7 +37,6 @@ typedef struct
 
 typedef struct
 {
-    BPL_Status_t (*Initialize_Impl)(void);
     BPL_Status_t (*SendEvent_Impl)(uint16_t EventID, BPL_EVM_EventType_t EventType,
         char const * EventText, va_list EventTextArgPtr);
 } BPL_EVM_ProxyCallbacks_t;

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -37,6 +37,7 @@ typedef struct
 
 typedef struct
 {
+    BPL_Status_t (*Initialize_Impl)(void);
     BPL_Status_t (*SendEvent_Impl)(uint16_t EventID, BPL_EVM_EventType_t EventType,
         char const * EventText, va_list EventTextArgPtr);
 } BPL_EVM_ProxyCallbacks_t;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -11,6 +11,7 @@ set(bplib_base_SOURCES
     src/v7_cla_api.c
     src/v7_dataservice_api.c
     src/v7_routing.c
+    src/bpl_evm_api.c
 )
 
 add_library(bplib_base OBJECT

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -28,31 +28,17 @@ BPL_EVM_ProxyCallbacks_t BPL_EVM_ProxyCallbacks;
 BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks)
 {
     BPL_Status_t ReturnStatus;
-    BPL_Status_t ProxyInitImplReturnStatus;
 
-    if ((ProxyCallbacks.Initialize_Impl == NULL) || (ProxyCallbacks.SendEvent_Impl == NULL))
+    if (ProxyCallbacks.SendEvent_Impl == NULL)
     {
         ReturnStatus.ReturnValue = BPL_STATUS_ERROR_INPUT_INVALID;
         OS_printf("BPL_EVM_Initialize got an invalid argument!\n");
     }
     else
     {
-        /* impl callbacks determined to be valid */
-        BPL_EVM_ProxyCallbacks.Initialize_Impl = ProxyCallbacks.Initialize_Impl;
+        /* store the function pointer, now that impl callback determined to be valid */
         BPL_EVM_ProxyCallbacks.SendEvent_Impl = ProxyCallbacks.SendEvent_Impl;
-
-        /* TODO: immediately want to call the proxy init, or wait for a directive to do so? */
-        ProxyInitImplReturnStatus = BPL_EVM_ProxyCallbacks.Initialize_Impl();
-        if (ProxyInitImplReturnStatus.ReturnValue != BPL_STATUS_SUCCESS)
-        {
-            ReturnStatus.ReturnValue = BPL_STATUS_ERROR_PROXY_INIT;
-            OS_printf("BPL_EVM_Initialize hit error (%u) when calling proxy init!\n",
-                ProxyInitImplReturnStatus.ReturnValue);
-        }
-        else
-        {
-            ReturnStatus.ReturnValue = BPL_STATUS_SUCCESS;
-        }
+        ReturnStatus.ReturnValue = BPL_STATUS_SUCCESS;
     }
 
     return ReturnStatus;
@@ -127,7 +113,6 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
 void BPL_EVM_Deinitialize(void)
 {
     /* Clear proxy function pointers */
-    BPL_EVM_ProxyCallbacks.Initialize_Impl = NULL;
     BPL_EVM_ProxyCallbacks.SendEvent_Impl = NULL;
 
     return;

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -105,7 +105,7 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
     }
     else
     {
-        ProxyReturnStatus = BPL_EVM_ProxyCallbacks.SendEvent_Impl(EventID);
+        ProxyReturnStatus = BPL_EVM_ProxyCallbacks.SendEvent_Impl(EventID, EventType);
         if (ProxyReturnStatus.ReturnValue != BPL_STATUS_SUCCESS)
         {
             ReturnStatus.ReturnValue = BPL_STATUS_ERROR_GENERAL;

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -88,15 +88,16 @@ char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type)
     }
 }
 
-BPL_Status_t BPL_EVM_SendEvent(BPL_EVM_EventInfo_t const * EventInfo, char const * EventText, ...)
+BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
+    char const * EventText, ...)
 {
     BPL_Status_t ReturnStatus;
     BPL_Status_t ProxyReturnStatus;
 
-    char const * EventTypeString = BPL_EVM_EventTypeToString(EventInfo->Type);
+    char const * EventTypeString = BPL_EVM_EventTypeToString(EventType);
     OS_printf("BPL_EVM_SendEvent called! Event Info (%s, %u).\n",
         EventTypeString,
-        EventInfo->ID);
+        EventID);
 
     if (BPL_EVM_ProxyCallbacks.SendEvent_Impl == NULL)
     {
@@ -104,7 +105,7 @@ BPL_Status_t BPL_EVM_SendEvent(BPL_EVM_EventInfo_t const * EventInfo, char const
     }
     else
     {
-        ProxyReturnStatus = BPL_EVM_ProxyCallbacks.SendEvent_Impl(EventInfo->ID);
+        ProxyReturnStatus = BPL_EVM_ProxyCallbacks.SendEvent_Impl(EventID);
         if (ProxyReturnStatus.ReturnValue != BPL_STATUS_SUCCESS)
         {
             ReturnStatus.ReturnValue = BPL_STATUS_ERROR_GENERAL;

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -6,6 +6,7 @@
  INCLUDES
  ******************************************************************************/
 
+#include <stdarg.h>
 #include "cfe.h"
 #include "bpl_evm_api.h"
 
@@ -93,6 +94,7 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
 {
     BPL_Status_t ReturnStatus;
     BPL_Status_t ProxyReturnStatus;
+    va_list EventTextArgsPtr;
 
     char const * EventTypeString = BPL_EVM_EventTypeToString(EventType);
     OS_printf("BPL_EVM_SendEvent called! Event Info (%s, %u).\n",
@@ -101,11 +103,18 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
 
     if (BPL_EVM_ProxyCallbacks.SendEvent_Impl == NULL)
     {
+        ReturnStatus.ReturnValue = BPL_STATUS_ERROR_PROXY_INIT;
+    }
+    else if (EventText == NULL)
+    {
         ReturnStatus.ReturnValue = BPL_STATUS_ERROR_INPUT_INVALID;
     }
     else
     {
-        ProxyReturnStatus = BPL_EVM_ProxyCallbacks.SendEvent_Impl(EventID, EventType);
+        va_start(EventTextArgsPtr, EventText);
+        ProxyReturnStatus = BPL_EVM_ProxyCallbacks.SendEvent_Impl(EventID, EventType, EventText, EventTextArgsPtr);
+        va_end(EventTextArgsPtr);
+
         if (ProxyReturnStatus.ReturnValue != BPL_STATUS_SUCCESS)
         {
             ReturnStatus.ReturnValue = BPL_STATUS_ERROR_GENERAL;

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -1,0 +1,41 @@
+/*
+ * TODO: Fill in file header, if necessary.
+ */
+
+/******************************************************************************
+ INCLUDES
+ ******************************************************************************/
+
+#include "cfe.h"
+// #include "bplib.h"
+// #include "bplib_os.h"
+// #include "v7.h"
+// #include "bplib_dataservice.h"
+// #include "v7_base_internal.h"
+#include "bpl_evm_api.h"
+
+/******************************************************************************
+ TYPEDEFS
+ ******************************************************************************/
+
+
+
+/******************************************************************************
+ LOCAL FUNCTIONS
+ ******************************************************************************/
+
+BPL_Status_t BPL_EVM_Initialize(void)
+{
+    BPL_Status_t ReturnStatus = { .ReturnValue = 0 };
+    OS_printf("BPL_EVM_Initialize called!\n");
+    return ReturnStatus;
+}
+
+BPL_Status_t BPL_EVM_SendEvent(BPL_EVM_EventInfo_t const * EventInfo, char const * EventText, ...)
+{
+    BPL_Status_t ReturnStatus = { .ReturnValue = 0 };
+    // char * EventTypeString = BPL_EVM_EventTypeToString(EventInfo.Type);
+    OS_printf("BPL_EVM_SendEvent called! Event Info (...).\n");
+    // OS_printf("BPL_EVM_SendEvent called with arg 0x%08X!\n", EventID);
+    return ReturnStatus;
+}

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -121,3 +121,15 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
 
     return ReturnStatus;
 }
+
+void BPL_EVM_Deinitialize(void)
+{
+    /* Clear proxy function pointers */
+    BPL_EVM_ProxyCallbacks.Initialize_Impl = NULL;
+    BPL_EVM_ProxyCallbacks.SendEvent_Impl = NULL;
+
+    /* TODO: remove print? */
+    OS_printf("BPL_EVM_Deinitialize executed successfully!\n");
+
+    return;
+}

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -28,17 +28,31 @@ BPL_EVM_ProxyCallbacks_t BPL_EVM_ProxyCallbacks;
 BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks)
 {
     BPL_Status_t ReturnStatus;
+    BPL_Status_t ProxyInitImplReturnStatus;
 
-    if (ProxyCallbacks.SendEvent_Impl == NULL)
+    if ((ProxyCallbacks.Initialize_Impl == NULL) || (ProxyCallbacks.SendEvent_Impl == NULL))
     {
         ReturnStatus.ReturnValue = BPL_STATUS_ERROR_INPUT_INVALID;
         OS_printf("BPL_EVM_Initialize got an invalid argument!\n");
     }
     else
     {
-        /* store the function pointer, now that impl callback determined to be valid */
+        /* impl callbacks determined to be valid */
+        BPL_EVM_ProxyCallbacks.Initialize_Impl = ProxyCallbacks.Initialize_Impl;
         BPL_EVM_ProxyCallbacks.SendEvent_Impl = ProxyCallbacks.SendEvent_Impl;
-        ReturnStatus.ReturnValue = BPL_STATUS_SUCCESS;
+
+        /* TODO: immediately want to call the proxy init, or wait for a directive to do so? */
+        ProxyInitImplReturnStatus = BPL_EVM_ProxyCallbacks.Initialize_Impl();
+        if (ProxyInitImplReturnStatus.ReturnValue != BPL_STATUS_SUCCESS)
+        {
+            ReturnStatus.ReturnValue = BPL_STATUS_ERROR_PROXY_INIT;
+            OS_printf("BPL_EVM_Initialize hit error (%u) when calling proxy init!\n",
+                ProxyInitImplReturnStatus.ReturnValue);
+        }
+        else
+        {
+            ReturnStatus.ReturnValue = BPL_STATUS_SUCCESS;
+        }
     }
 
     return ReturnStatus;
@@ -113,6 +127,7 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
 void BPL_EVM_Deinitialize(void)
 {
     /* Clear proxy function pointers */
+    BPL_EVM_ProxyCallbacks.Initialize_Impl = NULL;
     BPL_EVM_ProxyCallbacks.SendEvent_Impl = NULL;
 
     return;

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -52,7 +52,6 @@ BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks)
         else
         {
             ReturnStatus.ReturnValue = BPL_STATUS_SUCCESS;
-            OS_printf("BPL_EVM_Initialize executed proxy init impl successfully!\n");
         }
     }
 
@@ -124,7 +123,6 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
         else
         {
             ReturnStatus.ReturnValue = BPL_STATUS_SUCCESS;
-            OS_printf("BPL_EVM_SendEvent executed proxy impl successfully!\n");
         }
     }
 
@@ -136,9 +134,6 @@ void BPL_EVM_Deinitialize(void)
     /* Clear proxy function pointers */
     BPL_EVM_ProxyCallbacks.Initialize_Impl = NULL;
     BPL_EVM_ProxyCallbacks.SendEvent_Impl = NULL;
-
-    /* TODO: remove print? */
-    OS_printf("BPL_EVM_Deinitialize executed successfully!\n");
 
     return;
 }

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -7,11 +7,6 @@
  ******************************************************************************/
 
 #include "cfe.h"
-// #include "bplib.h"
-// #include "bplib_os.h"
-// #include "v7.h"
-// #include "bplib_dataservice.h"
-// #include "v7_base_internal.h"
 #include "bpl_evm_api.h"
 
 /******************************************************************************
@@ -31,11 +26,42 @@ BPL_Status_t BPL_EVM_Initialize(void)
     return ReturnStatus;
 }
 
+char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type)
+{
+    /* BPL_EVM_EventTypeStrings should always match BPL_EVM_EventType_t. */
+    static char const * BPL_EVM_EventTypeStrings[] = {
+        "UNKNOWN",
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL"
+    };
+
+    switch (Type)
+    {
+        case BPL_EVM_EventType_DEBUG:
+            return BPL_EVM_EventTypeStrings[1];
+        case BPL_EVM_EventType_INFO:
+            return BPL_EVM_EventTypeStrings[2];
+        case BPL_EVM_EventType_WARNING:
+            return BPL_EVM_EventTypeStrings[3];
+        case BPL_EVM_EventType_ERROR:
+            return BPL_EVM_EventTypeStrings[4];
+        case BPL_EVM_EventType_CRITICAL:
+            return BPL_EVM_EventTypeStrings[5];
+        default:
+            /* This default case also captures the BPL_EVM_EventType_UNKNOWN case. */
+            return BPL_EVM_EventTypeStrings[0];
+    }
+}
+
 BPL_Status_t BPL_EVM_SendEvent(BPL_EVM_EventInfo_t const * EventInfo, char const * EventText, ...)
 {
     BPL_Status_t ReturnStatus = { .ReturnValue = 0 };
-    // char * EventTypeString = BPL_EVM_EventTypeToString(EventInfo.Type);
-    OS_printf("BPL_EVM_SendEvent called! Event Info (...).\n");
-    // OS_printf("BPL_EVM_SendEvent called with arg 0x%08X!\n", EventID);
+    char const * EventTypeString = BPL_EVM_EventTypeToString(EventInfo->Type);
+    OS_printf("BPL_EVM_SendEvent called! Event Info (%s, %u).\n",
+        EventTypeString,
+        EventInfo->ID);
     return ReturnStatus;
 }

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -95,11 +95,6 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
     BPL_Status_t ProxyReturnStatus;
     va_list EventTextArgsPtr;
 
-    char const * EventTypeString = BPL_EVM_EventTypeToString(EventType);
-    OS_printf("BPL_EVM_SendEvent called! Event Info (%s, %u).\n",
-        EventTypeString,
-        EventID);
-
     if (BPL_EVM_ProxyCallbacks.SendEvent_Impl == NULL)
     {
         ReturnStatus.ReturnValue = BPL_STATUS_ERROR_PROXY_INIT;

--- a/ut-stubs/CMakeLists.txt
+++ b/ut-stubs/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(coverage-bplib-stubs
     bplib_stubs.c
     bplib_routing_stubs.c
+    bpl_evm_api_stubs.c
 )
 target_include_directories(coverage-bplib-stubs PUBLIC
     $<TARGET_PROPERTY:bplib,INTERFACE_INCLUDE_DIRECTORIES>

--- a/ut-stubs/bpl_evm_api_stubs.c
+++ b/ut-stubs/bpl_evm_api_stubs.c
@@ -13,7 +13,6 @@
 #include "bpl_evm_api.h"
 #include "utgenstub.h"
 
-
 /*
  * ----------------------------------------------------
  * Generated stub function for BPL_EVM_Deinitialize()
@@ -22,8 +21,7 @@
 void BPL_EVM_Deinitialize(void)
 {
 
-UT_GenStub_Execute(BPL_EVM_Deinitialize, Basic, NULL);
-
+    UT_GenStub_Execute(BPL_EVM_Deinitialize, Basic, NULL);
 }
 
 /*
@@ -31,15 +29,15 @@ UT_GenStub_Execute(BPL_EVM_Deinitialize, Basic, NULL);
  * Generated stub function for BPL_EVM_EventTypeToString()
  * ----------------------------------------------------
  */
-char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type)
+char const *BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type)
 {
-UT_GenStub_SetupReturnBuffer(BPL_EVM_EventTypeToString, char const *);
+    UT_GenStub_SetupReturnBuffer(BPL_EVM_EventTypeToString, char const *);
 
-UT_GenStub_AddParam(BPL_EVM_EventTypeToString, BPL_EVM_EventType_t , Type);
+    UT_GenStub_AddParam(BPL_EVM_EventTypeToString, BPL_EVM_EventType_t, Type);
 
-UT_GenStub_Execute(BPL_EVM_EventTypeToString, Basic, NULL);
+    UT_GenStub_Execute(BPL_EVM_EventTypeToString, Basic, NULL);
 
-return UT_GenStub_GetReturnValue(BPL_EVM_EventTypeToString, char const *);
+    return UT_GenStub_GetReturnValue(BPL_EVM_EventTypeToString, char const *);
 }
 
 /*
@@ -49,13 +47,13 @@ return UT_GenStub_GetReturnValue(BPL_EVM_EventTypeToString, char const *);
  */
 BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks)
 {
-UT_GenStub_SetupReturnBuffer(BPL_EVM_Initialize, BPL_Status_t);
+    UT_GenStub_SetupReturnBuffer(BPL_EVM_Initialize, BPL_Status_t);
 
-UT_GenStub_AddParam(BPL_EVM_Initialize, BPL_EVM_ProxyCallbacks_t , ProxyCallbacks);
+    UT_GenStub_AddParam(BPL_EVM_Initialize, BPL_EVM_ProxyCallbacks_t, ProxyCallbacks);
 
-UT_GenStub_Execute(BPL_EVM_Initialize, Basic, NULL);
+    UT_GenStub_Execute(BPL_EVM_Initialize, Basic, NULL);
 
-return UT_GenStub_GetReturnValue(BPL_EVM_Initialize, BPL_Status_t);
+    return UT_GenStub_GetReturnValue(BPL_EVM_Initialize, BPL_Status_t);
 }
 
 /*
@@ -63,20 +61,19 @@ return UT_GenStub_GetReturnValue(BPL_EVM_Initialize, BPL_Status_t);
  * Generated stub function for BPL_EVM_SendEvent()
  * ----------------------------------------------------
  */
-BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType, char const * EventText, ...)
+BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType, char const *EventText, ...)
 {
-va_list UtStub_ArgList;
+    va_list UtStub_ArgList;
 
-UT_GenStub_SetupReturnBuffer(BPL_EVM_SendEvent, BPL_Status_t);
+    UT_GenStub_SetupReturnBuffer(BPL_EVM_SendEvent, BPL_Status_t);
 
-UT_GenStub_AddParam(BPL_EVM_SendEvent, uint16_t , EventID);
-UT_GenStub_AddParam(BPL_EVM_SendEvent, BPL_EVM_EventType_t , EventType);
-UT_GenStub_AddParam(BPL_EVM_SendEvent, char const * , EventText);
+    UT_GenStub_AddParam(BPL_EVM_SendEvent, uint16_t, EventID);
+    UT_GenStub_AddParam(BPL_EVM_SendEvent, BPL_EVM_EventType_t, EventType);
+    UT_GenStub_AddParam(BPL_EVM_SendEvent, char const *, EventText);
 
-va_start(UtStub_ArgList, EventText);
-UT_GenStub_Execute(BPL_EVM_SendEvent, Va, NULL, UtStub_ArgList);
-va_end(UtStub_ArgList);
+    va_start(UtStub_ArgList, EventText);
+    UT_GenStub_Execute(BPL_EVM_SendEvent, Va, NULL, UtStub_ArgList);
+    va_end(UtStub_ArgList);
 
-return UT_GenStub_GetReturnValue(BPL_EVM_SendEvent, BPL_Status_t);
+    return UT_GenStub_GetReturnValue(BPL_EVM_SendEvent, BPL_Status_t);
 }
-

--- a/ut-stubs/bpl_evm_api_stubs.c
+++ b/ut-stubs/bpl_evm_api_stubs.c
@@ -1,0 +1,82 @@
+/*
+ * TODO: Fill in file header, if necessary.
+ */
+
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in bpl_evm_api header
+ */
+
+#include <stdarg.h>
+
+#include "bpl_evm_api.h"
+#include "utgenstub.h"
+
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for BPL_EVM_Deinitialize()
+ * ----------------------------------------------------
+ */
+void BPL_EVM_Deinitialize(void)
+{
+
+UT_GenStub_Execute(BPL_EVM_Deinitialize, Basic, NULL);
+
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for BPL_EVM_EventTypeToString()
+ * ----------------------------------------------------
+ */
+char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type)
+{
+UT_GenStub_SetupReturnBuffer(BPL_EVM_EventTypeToString, char const *);
+
+UT_GenStub_AddParam(BPL_EVM_EventTypeToString, BPL_EVM_EventType_t , Type);
+
+UT_GenStub_Execute(BPL_EVM_EventTypeToString, Basic, NULL);
+
+return UT_GenStub_GetReturnValue(BPL_EVM_EventTypeToString, char const *);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for BPL_EVM_Initialize()
+ * ----------------------------------------------------
+ */
+BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks)
+{
+UT_GenStub_SetupReturnBuffer(BPL_EVM_Initialize, BPL_Status_t);
+
+UT_GenStub_AddParam(BPL_EVM_Initialize, BPL_EVM_ProxyCallbacks_t , ProxyCallbacks);
+
+UT_GenStub_Execute(BPL_EVM_Initialize, Basic, NULL);
+
+return UT_GenStub_GetReturnValue(BPL_EVM_Initialize, BPL_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for BPL_EVM_SendEvent()
+ * ----------------------------------------------------
+ */
+BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType, char const * EventText, ...)
+{
+va_list UtStub_ArgList;
+
+UT_GenStub_SetupReturnBuffer(BPL_EVM_SendEvent, BPL_Status_t);
+
+UT_GenStub_AddParam(BPL_EVM_SendEvent, uint16_t , EventID);
+UT_GenStub_AddParam(BPL_EVM_SendEvent, BPL_EVM_EventType_t , EventType);
+UT_GenStub_AddParam(BPL_EVM_SendEvent, char const * , EventText);
+
+va_start(UtStub_ArgList, EventText);
+UT_GenStub_Execute(BPL_EVM_SendEvent, Va, NULL, UtStub_ArgList);
+va_end(UtStub_ArgList);
+
+return UT_GenStub_GetReturnValue(BPL_EVM_SendEvent, BPL_Status_t);
+}
+


### PR DESCRIPTION
**Describe the contribution**

This PR add prototype implementations for the BPLib's Event Management (EVM) design (part of the Core Infrastructure).
This design intends to abstract the cFS EVS API calls from the BP App, using a new EVM API the BPLib.
A related PR exists for BP app, here: https://github.com/keegan-moore/bp/pull/1 .


**Testing performed**

1. Build steps
    1. `make native.distclean`
    2.`make ENABLE_TESTS=false native.install` 
1. Execution steps '...'
    1. `cd build-native-9.4.0/exe/cpu1`
    2. `./core-cpu1`

**Expected behavior changes**

A clear and concise description of how this contribution will change behavior and level of impact.

 - API Changes:
     - During BP app initialization, BP is now expected to call `BPL_EVM_Initialize` instead of `CFE_EVS_Register`
     - When the BP app wants to generate an event, the app should now use `BPL_EVM_SendEvent`
 - Behavior Change:
     - No changes to behavior

**System(s) tested on**
 - Hardware: PC / x86_64
 - OS: Ubuntu 22.04
 - Versions: cFE 6.7 (equuleus) release candidate

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Keegan Moore, NASA/GSFC Code 582 (Flight Software Systems)
