### PR TITLE
Move EVM's proxy API function pointers into BPL mpool

### DIFF
--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -9,6 +9,7 @@
  INCLUDES
  ******************************************************************************/
 
+#include <stdarg.h>
 #include "bplib_api_types.h"
 
 /************************************************
@@ -46,7 +47,7 @@ typedef struct
  * Exported Functions
  ************************************************/
 
-BPL_Status_t BPL_EVM_Initialize(bplib_mpool_t * this, BPL_EVM_ProxyCallbacks_t ProxyCallbacks);
+BPL_Status_t BPL_EVM_Initialize(bplib_mpool_t * this, BPL_EVM_ProxyCallbacks_t * ProxyCallbacks);
 char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type);
 BPL_Status_t BPL_EVM_SendEvent(bplib_mpool_t * this, uint16_t EventID, BPL_EVM_EventType_t EventType,
                                 char const * EventText, ...);

--- a/inc/bpl_evm_api.h
+++ b/inc/bpl_evm_api.h
@@ -46,10 +46,10 @@ typedef struct
  * Exported Functions
  ************************************************/
 
-BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks);
+BPL_Status_t BPL_EVM_Initialize(bplib_mpool_t * this, BPL_EVM_ProxyCallbacks_t ProxyCallbacks);
 char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type);
-BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
+BPL_Status_t BPL_EVM_SendEvent(bplib_mpool_t * this, uint16_t EventID, BPL_EVM_EventType_t EventType,
                                 char const * EventText, ...);
-void BPL_EVM_Deinitialize(void);
+void BPL_EVM_Deinitialize(bplib_mpool_t * this);
 
 #endif /* BPL_EVM_H */

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -8,7 +8,10 @@
 
 #include <stdarg.h>
 #include "cfe.h"
+#include "bplib_api_types.h"
+#include "bplib_routing.h"
 #include "bpl_evm_api.h"
+//#include "v7_mpool_internal.h"
 
 /******************************************************************************
  TYPEDEFS
@@ -19,18 +22,83 @@
  LOCAL DATA
  ******************************************************************************/
 
-BPL_EVM_ProxyCallbacks_t BPL_EVM_ProxyCallbacks;
+// BPL_EVM_ProxyCallbacks_t BPL_EVM_ProxyCallbacks;
 
 /******************************************************************************
  LOCAL FUNCTIONS
  ******************************************************************************/
 
-BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks)
+BPL_EVM_ProxyCallbacks_t * BPL_EVM_GetAPIFromRouteTbl(bplib_routetbl_t * routetbl)
+{
+    BPL_EVM_ProxyCallbacks_t * EVM_API;
+    bplib_mpool_t * mpool;
+
+    if (routetbl == NULL)
+    {
+        EVM_API = NULL;
+    }
+    else
+    {
+        mpool = bplib_route_get_mpool(routetbl);
+        if (mpool == NULL)
+        {
+            EVM_API = NULL;
+        }
+        else
+        {
+            EVM_API = this->admin_block.u.admin.EVM_API;
+        }
+    }
+
+    return EVM_API;
+}
+
+/*
+** Helper function to find/return the EVM API Proxy Callback struct from inside the mempool
+*/
+BPL_EVM_ProxyCallbacks_t * BPL_EVM_GetAPI(bplib_mpool_t const * this)
+{
+    BPL_EVM_ProxyCallbacks_t * EVM_API;
+    if (this == NULL)
+    {
+        EVM_API = NULL;
+    }
+    else
+    {
+        EVM_API = this->admin_block.u.admin.EVM_API;
+    }
+    return EVM_API;
+}
+
+bool BPL_EVM_IsValidAPI(BPL_EVM_ProxyCallbacks_t const * api)
+{
+    bool IsValid;
+    if (api == NULL)
+    {
+        IsValid = false;
+    }
+    else if (api->Initialize_Impl == NULL)
+    {
+        IsValid = false;
+    }
+    else if (api->SendEvent_Impl == NULL)
+    {
+        IsValid = false;
+    }
+    else
+    {
+        IsValid = true;
+    }
+    return IsValid;
+}
+
+BPL_Status_t BPL_EVM_Initialize(bplib_mpool_t * this, BPL_EVM_ProxyCallbacks_t ProxyCallbacks)
 {
     BPL_Status_t ReturnStatus;
     BPL_Status_t ProxyInitImplReturnStatus;
+    BPL_EVM_ProxyCallbacks_t * EVM_API = BPL_EVM_GetAPI(this);
 
-    if ((ProxyCallbacks.Initialize_Impl == NULL) || (ProxyCallbacks.SendEvent_Impl == NULL))
+    if (BPL_EVM_IsValidAPI(EVM_API) || BPL_EVM_IsValidAPI(&ProxyCallbacks))
     {
         ReturnStatus.ReturnValue = BPL_STATUS_ERROR_INPUT_INVALID;
         OS_printf("BPL_EVM_Initialize got an invalid argument!\n");
@@ -38,11 +106,11 @@ BPL_Status_t BPL_EVM_Initialize(BPL_EVM_ProxyCallbacks_t ProxyCallbacks)
     else
     {
         /* impl callbacks determined to be valid */
-        BPL_EVM_ProxyCallbacks.Initialize_Impl = ProxyCallbacks.Initialize_Impl;
-        BPL_EVM_ProxyCallbacks.SendEvent_Impl = ProxyCallbacks.SendEvent_Impl;
+        EVM_API->Initialize_Impl = ProxyCallbacks.Initialize_Impl;
+        EVM_API->SendEvent_Impl = ProxyCallbacks.SendEvent_Impl;
 
         /* TODO: immediately want to call the proxy init, or wait for a directive to do so? */
-        ProxyInitImplReturnStatus = BPL_EVM_ProxyCallbacks.Initialize_Impl();
+        ProxyInitImplReturnStatus = EVM_API->Initialize_Impl();
         if (ProxyInitImplReturnStatus.ReturnValue != BPL_STATUS_SUCCESS)
         {
             ReturnStatus.ReturnValue = BPL_STATUS_ERROR_PROXY_INIT;
@@ -88,14 +156,15 @@ char const * BPL_EVM_EventTypeToString(BPL_EVM_EventType_t Type)
     }
 }
 
-BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
+BPL_Status_t BPL_EVM_SendEvent(bplib_mpool_t * this, uint16_t EventID, BPL_EVM_EventType_t EventType,
     char const * EventText, ...)
 {
     BPL_Status_t ReturnStatus;
     BPL_Status_t ProxyReturnStatus;
     va_list EventTextArgsPtr;
+    BPL_EVM_ProxyCallbacks_t const * EVM_API = BPL_EVM_GetAPI(this);
 
-    if (BPL_EVM_ProxyCallbacks.SendEvent_Impl == NULL)
+    if (BPL_EVM_IsValidAPI(EVM_API))
     {
         ReturnStatus.ReturnValue = BPL_STATUS_ERROR_PROXY_INIT;
     }
@@ -106,7 +175,7 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
     else
     {
         va_start(EventTextArgsPtr, EventText);
-        ProxyReturnStatus = BPL_EVM_ProxyCallbacks.SendEvent_Impl(EventID, EventType, EventText, EventTextArgsPtr);
+        ProxyReturnStatus = EVM_API->SendEvent_Impl(EventID, EventType, EventText, EventTextArgsPtr);
         va_end(EventTextArgsPtr);
 
         if (ProxyReturnStatus.ReturnValue != BPL_STATUS_SUCCESS)
@@ -124,11 +193,16 @@ BPL_Status_t BPL_EVM_SendEvent(uint16_t EventID, BPL_EVM_EventType_t EventType,
     return ReturnStatus;
 }
 
-void BPL_EVM_Deinitialize(void)
+void BPL_EVM_Deinitialize(bplib_mpool_t * this)
 {
-    /* Clear proxy function pointers */
-    BPL_EVM_ProxyCallbacks.Initialize_Impl = NULL;
-    BPL_EVM_ProxyCallbacks.SendEvent_Impl = NULL;
+    BPL_EVM_ProxyCallbacks_t * EVM_API = BPL_EVM_GetAPI(this);
+
+    if (BPL_EVM_IsValidAPI(EVM_API))
+    {
+        /* Clear proxy function pointers */
+        EVM_API->Initialize_Impl = NULL;
+        EVM_API->SendEvent_Impl = NULL;
+    }
 
     return;
 }

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -133,7 +133,7 @@ BPL_Status_t BPL_EVM_SendEvent(bplib_mpool_t * this, uint16_t EventID, BPL_EVM_E
     va_list EventTextArgsPtr;
     BPL_EVM_ProxyCallbacks_t const * EVM_API = BPL_EVM_GetAPI(this);
 
-    if (BPL_EVM_IsValidAPI(EVM_API))
+    if (BPL_EVM_IsValidAPI(EVM_API) == false)
     {
         ReturnStatus.ReturnValue = BPL_STATUS_ERROR_PROXY_INIT;
     }

--- a/lib/src/bpl_evm_api.c
+++ b/lib/src/bpl_evm_api.c
@@ -46,7 +46,7 @@ BPL_EVM_ProxyCallbacks_t * BPL_EVM_GetAPIFromRouteTbl(bplib_routetbl_t * routetb
         }
         else
         {
-            EVM_API = this->admin_block.u.admin.EVM_API;
+            EVM_API = routetbl->admin_block.u.admin.EVM_API;
         }
     }
 

--- a/mpool/inc/v7_mpool.h
+++ b/mpool/inc/v7_mpool.h
@@ -24,6 +24,7 @@
 #include <string.h>
 
 #include "bplib_api_types.h"
+#include "bpl_evm_api.h"
 
 /*
  * Priority levels for pool buffers -
@@ -358,6 +359,16 @@ void bplib_mpool_init_secondary_link(bplib_mpool_block_t *base_block, bplib_mpoo
  * @retval NULL if the lblk pointer is not convertible to a content block
  */
 bplib_mpool_block_t *bplib_mpool_get_block_from_link(bplib_mpool_block_t *lblk);
+
+
+/*
+ * @brief Obtain the pointer to the EVM API from the admin block
+ *
+ * @param[in] lblk link structure, such as from a list traversal.  May be a secondary link.
+ * @return bplib_mpool_block_t* pointer to container block
+ * @retval NULL if the lblk pointer is not convertible to a content block
+*/
+BPL_EVM_ProxyCallbacks_t * bplib_mpool_get_evm_api(bplib_mpool_t * this);
 
 /**
  * @brief Gets the offset of the block user content section

--- a/mpool/src/v7_mpool.c
+++ b/mpool/src/v7_mpool.c
@@ -157,6 +157,29 @@ bplib_mpool_block_t *bplib_mpool_get_block_from_link(bplib_mpool_block_t *lblk)
     return bblk;
 }
 
+
+/*
+** Helper function to find/return the EVM API Proxy Callback struct from inside the mempool
+*/
+BPL_EVM_ProxyCallbacks_t * bplib_mpool_get_evm_api(bplib_mpool_t * this)
+{
+    BPL_EVM_ProxyCallbacks_t * EVM_API;
+    if (this == NULL)
+    {
+        EVM_API = NULL;
+    }
+    else
+    {
+        /*
+        ** TODO: do we need to search throught the list,
+        **       or can we assume this is the admin block?
+        */
+        EVM_API = &this->admin_block.u.admin.evm_api;
+    }
+    return EVM_API;
+}
+
+
 /*----------------------------------------------------------------
  *
  * Function: bplib_mpool_get_block_content

--- a/mpool/src/v7_mpool_internal.h
+++ b/mpool/src/v7_mpool_internal.h
@@ -31,6 +31,7 @@
 #include "v7_mpool_bblocks.h"
 #include "v7_mpool_flows.h"
 #include "v7_mpool_ref.h"
+#include "bpl_evm_api.h"
 
 /*
  * Minimum size of a generic data block
@@ -124,6 +125,8 @@ typedef struct bplib_mpool_block_admin_content
      * is not used for these, because the push_count and pull_count would not remain accurate. */
 
     bplib_mpool_block_t active_list; /**< a list of flows/queues that need processing */
+
+    BPL_EVM_ProxyCallbacks_t evm_api;
 
 } bplib_mpool_block_admin_content_t;
 


### PR DESCRIPTION
**Describe the contribution**

This PR moves the EVM's proxy API function pointers into the existing mpool struct (in BPL).

The related PR for BP is here: https://github.com/keegan-moore/bp/pull/2

This work is based off of another feature, related to these two PRs:

1. https://github.com/keegan-moore/bplib/pull/1
2. https://github.com/keegan-moore/bp/pull/1

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
1. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
- If NASA Civil Servant Employee or GSFC Contractor on SES III
  - Address/email/phone and contract/task information (if applicable) must be on file
- Else if Company
  - **HAND SIGNED** Company CLA must be on file (once per release): [Company CLA](https://github.com/nasa/bplib/blob/main/doc/GSC_18318_Corp_CLA_form_1219.pdf)
- Else if Individual
  - **HAND SIGNED** Individual CLA must be on file (once per release): [Individual CLA](https://github.com/nasa/bplib/blob/main/doc/GSC_18318_Ind_CLA_form_1219.pdf)
